### PR TITLE
Add the implementation of AFN and Add residual part in Autoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This package provides a PyTorch implementation of factorization machine models a
 | DeepFM | [H Guo, et al. DeepFM: A Factorization-Machine based Neural Network for CTR Prediction, 2017.](https://arxiv.org/abs/1703.04247) |
 | xDeepFM | [J Lian, et al. xDeepFM: Combining Explicit and Implicit Feature Interactions for Recommender Systems, 2018.](https://arxiv.org/abs/1803.05170) |
 | AutoInt (Automatic Feature Interaction Model) | [W Song, et al. AutoInt: Automatic Feature Interaction Learning via Self-Attentive Neural Networks, 2018.](https://arxiv.org/abs/1810.11921) |
-| AFN(AdaptiveFactorizationNetwork Model) | [Cheng W, et al. Adaptive Factorization Network: Learning Adaptive-Order Feature Interactions,AAAI'20.](https://arxiv.org/pdf/1909.03276.pdf) |
+| AFN(AdaptiveFactorizationNetwork Model) | [Cheng W, et al. Adaptive Factorization Network: Learning Adaptive-Order Feature Interactions, AAAI'20.](https://arxiv.org/pdf/1909.03276.pdf) |
 
 Each model's AUC values are about 0.80 for criteo dataset, and about 0.78 for avazu dataset. (please see [example code](examples/main.py))
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This package provides a PyTorch implementation of factorization machine models a
 | DeepFM | [H Guo, et al. DeepFM: A Factorization-Machine based Neural Network for CTR Prediction, 2017.](https://arxiv.org/abs/1703.04247) |
 | xDeepFM | [J Lian, et al. xDeepFM: Combining Explicit and Implicit Feature Interactions for Recommender Systems, 2018.](https://arxiv.org/abs/1803.05170) |
 | AutoInt (Automatic Feature Interaction Model) | [W Song, et al. AutoInt: Automatic Feature Interaction Learning via Self-Attentive Neural Networks, 2018.](https://arxiv.org/abs/1810.11921) |
+| AFN (AdaptiveFactorizationNetwork Model) | [Cheng W, et al. Adaptive Factorization Network: Learning Adaptive-Order Feature Interactions, .](https://arxiv.org/pdf/1909.03276.pdf) |
 
 Each model's AUC values are about 0.80 for criteo dataset, and about 0.78 for avazu dataset. (please see [example code](examples/main.py))
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This package provides a PyTorch implementation of factorization machine models a
 | DeepFM | [H Guo, et al. DeepFM: A Factorization-Machine based Neural Network for CTR Prediction, 2017.](https://arxiv.org/abs/1703.04247) |
 | xDeepFM | [J Lian, et al. xDeepFM: Combining Explicit and Implicit Feature Interactions for Recommender Systems, 2018.](https://arxiv.org/abs/1803.05170) |
 | AutoInt (Automatic Feature Interaction Model) | [W Song, et al. AutoInt: Automatic Feature Interaction Learning via Self-Attentive Neural Networks, 2018.](https://arxiv.org/abs/1810.11921) |
-| AFN (AdaptiveFactorizationNetwork Model) | [Cheng W, et al. Adaptive Factorization Network: Learning Adaptive-Order Feature Interactions, .](https://arxiv.org/pdf/1909.03276.pdf) |
+| AFN(AdaptiveFactorizationNetwork Model) | [Cheng W, et al. Adaptive Factorization Network: Learning Adaptive-Order Feature Interactions,AAAI'20.](https://arxiv.org/pdf/1909.03276.pdf) |
 
 Each model's AUC values are about 0.80 for criteo dataset, and about 0.78 for avazu dataset. (please see [example code](examples/main.py))
 

--- a/examples/main.py
+++ b/examples/main.py
@@ -20,6 +20,7 @@ from torchfm.model.nfm import NeuralFactorizationMachineModel
 from torchfm.model.pnn import ProductNeuralNetworkModel
 from torchfm.model.wd import WideAndDeepModel
 from torchfm.model.xdfm import ExtremeDeepFactorizationMachineModel
+from torchfm.model.afn import AdaptiveFactorizationNetwork
 
 
 def get_dataset(name, path):
@@ -76,6 +77,10 @@ def get_model(name, dataset):
     elif name == 'afi':
         return AutomaticFeatureInteractionModel(
              field_dims, embed_dim=16, atten_embed_dim=64, num_heads=2, num_layers=3, mlp_dims=(400, 400), dropouts=(0, 0, 0))
+    elif name == 'afn':
+        print("Model:AFN")
+        return AdaptiveFactorizationNetwork(
+            field_dims, embed_dim=16, LNN_dim=1500, mlp_dims=(400,400,400), dropouts=(0, 0, 0))
     else:
         raise ValueError('unknown model name: ' + name)
 

--- a/examples/main.py
+++ b/examples/main.py
@@ -75,7 +75,7 @@ def get_model(name, dataset):
         return AttentionalFactorizationMachineModel(field_dims, embed_dim=16, attn_size=16, dropouts=(0.2, 0.2))
     elif name == 'afi':
         return AutomaticFeatureInteractionModel(
-            field_dims, embed_dim=32, num_heads=4, num_layers=2, mlp_dims=(16, 16), dropouts=(0.2, 0.2))
+             field_dims, embed_dim=16, atten_embed_dim=64, num_heads=2, num_layers=3, mlp_dims=(400, 400), dropouts=(0, 0, 0))
     else:
         raise ValueError('unknown model name: ' + name)
 

--- a/torchfm/model/afi.py
+++ b/torchfm/model/afi.py
@@ -12,27 +12,36 @@ class AutomaticFeatureInteractionModel(torch.nn.Module):
         W Song, et al. AutoInt: Automatic Feature Interaction Learning via Self-Attentive Neural Networks, 2018.
     """
 
-    def __init__(self, field_dims, embed_dim, num_heads, num_layers, mlp_dims, dropouts):
+    def __init__(self, field_dims, embed_dim, atten_embed_dim, num_heads, num_layers, mlp_dims, dropouts, has_residual=True):
         super().__init__()
         self.num_fields = len(field_dims)
         self.linear = FeaturesLinear(field_dims)
         self.embedding = FeaturesEmbedding(field_dims, embed_dim)
+        self.atten_embedding = torch.nn.Linear(embed_dim, atten_embed_dim)
         self.embed_output_dim = len(field_dims) * embed_dim
+        self.atten_output_dim = len(field_dims) * atten_embed_dim
+        self.has_residual = has_residual
         self.mlp = MultiLayerPerceptron(self.embed_output_dim, mlp_dims, dropouts[1])
         self.self_attns = torch.nn.ModuleList([
-            torch.nn.MultiheadAttention(embed_dim, num_heads, dropout=dropouts[0]) for _ in range(num_layers)
+            torch.nn.MultiheadAttention(atten_embed_dim, num_heads, dropout=dropouts[0]) for _ in range(num_layers)
         ])
-        self.attn_fc = torch.nn.Linear(self.embed_output_dim, 1)
+        self.attn_fc = torch.nn.Linear(self.atten_output_dim, 1)
+        if self.has_residual:
+            self.V_res_embedding = torch.nn.Linear(embed_dim, atten_embed_dim)
 
     def forward(self, x):
         """
         :param x: Long tensor of size ``(batch_size, num_fields)``
         """
         embed_x = self.embedding(x)
-        cross_term = embed_x.transpose(0, 1)
+        atten_x = self.atten_embedding(embed_x)
+        cross_term = atten_x.transpose(0, 1)
         for self_attn in self.self_attns:
             cross_term, _ = self_attn(cross_term, cross_term, cross_term)
         cross_term = cross_term.transpose(0, 1)
-        cross_term = F.relu(cross_term).contiguous().view(-1, self.embed_output_dim)
+        if self.has_residual:
+            V_res = self.V_res_embedding(embed_x)
+            cross_term += V_res
+        cross_term = F.relu(cross_term).contiguous().view(-1, self.atten_output_dim)
         x = self.linear(x) + self.attn_fc(cross_term) + self.mlp(embed_x.view(-1, self.embed_output_dim))
         return torch.sigmoid(x.squeeze(1))

--- a/torchfm/model/afn.py
+++ b/torchfm/model/afn.py
@@ -1,0 +1,84 @@
+import math
+import torch
+import torch.nn.functional as F
+
+from torchfm.layer import FeaturesEmbedding, FeaturesLinear, MultiLayerPerceptron
+
+class LNN(torch.nn.Module):
+    """
+    A pytorch implementation of LNN layer
+    Input shape
+        - A 3D tensor with shape: ``(batch_size,field_size,embedding_size)``.
+    Output shape
+        - 2D tensor with shape:``(batch_size,LNN_dim*embedding_size)``.
+    Arguments
+        - **in_features** : Embedding of feature.
+        - **num_fields**: int.The field size of feature.
+        - **LNN_dim**: int.The number of Logarithmic neuron.
+        - **bias**: bool.Whether or not use bias in LNN.
+    """
+    def __init__(self, num_fields, embed_dim, LNN_dim, bias=False):
+        super(LNN, self).__init__()
+        self.num_fields = num_fields
+        self.embed_dim = embed_dim
+        self.LNN_dim = LNN_dim
+        self.lnn_output_dim = LNN_dim * embed_dim
+        self.weight = torch.nn.Parameter(torch.Tensor(LNN_dim, num_fields))
+        if bias:
+            self.bias = torch.nn.Parameter(torch.Tensor(LNN_dim, embed_dim))
+        else:
+            self.register_parameter('bias', None)
+        self.reset_parameters()
+    
+    def reset_parameters(self):
+        stdv = 1. / math.sqrt(self.weight.size(1))
+        self.weight.data.uniform_(-stdv, stdv)
+        if self.bias is not None:
+            self.bias.data.uniform_(-stdv, stdv)
+
+    def forward(self, x):
+        """
+        :param x: Long tensor of size ``(batch_size, num_fields, embedding_size)``
+        """
+        embed_x_abs = torch.abs(x) # Computes the element-wise absolute value of the given input tensor.
+        embed_x_afn = torch.add(embed_x_abs, 1e-7)
+        # Logarithmic Transformation
+        embed_x_log = torch.log1p(embed_x_afn) # torch.log1p and torch.expm1
+        lnn_out = torch.matmul(self.weight, embed_x_log)
+        if self.bias is not None:
+            lnn_out += self.bias
+        lnn_exp = torch.expm1(lnn_out)
+        output = F.relu(lnn_exp).contiguous().view(-1, self.lnn_output_dim)
+        return output
+
+
+
+
+
+
+class AdaptiveFactorizationNetwork(torch.nn.Module):
+    """
+    A pytorch implementation of AFN.
+
+    Reference:
+        Cheng W, et al. Adaptive Factorization Network: Learning Adaptive-Order Feature Interactions, 2019.
+    """
+    def __init__(self, field_dims, embed_dim, LNN_dim, mlp_dims, dropouts):
+        super().__init__()
+        self.num_fields = len(field_dims)
+        self.linear = FeaturesLinear(field_dims)    # Linear
+        self.embedding = FeaturesEmbedding(field_dims, embed_dim)   # Embedding
+        self.LNN_dim = LNN_dim
+        self.LNN_output_dim = self.LNN_dim * embed_dim
+        self.LNN = LNN(self.num_fields, embed_dim, LNN_dim)
+        self.mlp = MultiLayerPerceptron(self.LNN_output_dim, mlp_dims, dropouts[0])
+
+    def forward(self, x):
+        """
+        :param x: Long tensor of size ``(batch_size, num_fields)``
+        """
+        embed_x = self.embedding(x)
+        lnn_out = self.LNN(embed_x)
+        x = self.linear(x) + self.mlp(lnn_out)
+        return torch.sigmoid(x.squeeze(1))
+


### PR DESCRIPTION
The pytorch-fm is quite awesome, and it help me a lot in my research.To make it better, I did a little update as follows:
1.I did a little change to improve the performance of Autoint. According to the paper of Autoint and it's source code,  the model should contain the residual part in multihead_attention, which can improve the performance of AutoInt. Also,there maybe a little mistake in the implementation of AutoInt, according to the Author's source code of tensorflow, the embedding size is 16 but the embedding size of MultiheadAttention(the tf source code called block) is 64, they are different actually.
refer to:
https://github.com/DeepGraphLearning/RecommenderSystems/blob/master/featureRec/autoint/model.py#L48

2.I Add the implementation of AFN, which is the AAAI'20 paper about Deep CTR.
[Cheng W, et al. Adaptive Factorization Network: Learning Adaptive-Order Feature Interactions.AAAI'20](https://arxiv.org/pdf/1909.03276.pdf)

Thanks!